### PR TITLE
Update 10-row-level-security.md

### DIFF
--- a/Instructions/10-row-level-security.md
+++ b/Instructions/10-row-level-security.md
@@ -75,7 +75,7 @@ In this task, you'll enforce row-level security to ensure a salesperson can only
     
 	*You may recall that Michael Blythe is assigned to three sales regions: US Northeast, US Central, and US Southeast.*
 
-1. On the **Modeling** ribbon tab, from inside the **Security** group, select **Manage Roles**.
+1. On the **Home** ribbon tab, from inside the **Security** group, select **Manage Roles**.
 
     ![Picture 5700](Linked_image_Files/04-configure-data-model-in-power-bi-desktop-advanced_image21.png)
 


### PR DESCRIPTION
Exercise 1 Task 2 - Step 1 mention "Switch to Data View", but in this view does not exist the "Modeling tab".  Here, the "Manage Roles" is in the Home tab, security group.

Eventually, to use the "Modeling tab", the user should switch to Report view first, so in this case the Step 4 should read:

'Switch to **Report** view, then on the **Modeling** ribbon tab, from inside the **Security** group, select **Manage Roles**.'

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-