### PR TITLE
Correction for formula to create quick measure for Profit in Demo 5.

### DIFF
--- a/Instructions/Demos/05-create-measures-DAX.md
+++ b/Instructions/Demos/05-create-measures-DAX.md
@@ -51,7 +51,7 @@ Cost = 'Sales'[Quantity] * RELATED('Product'[Cost])
 
 ## Create a Quick Measure
 
-1. Add a quick measure to the Sales table, subtracting the Cost column from Profit column.
+1. Add a quick measure to the Sales table, subtracting the Cost column from Sales column.
 
 1. Rename the measure as Profit.
 


### PR DESCRIPTION
# Module: 00
## Lab/Demo: 05

Fixes # Create a Quick Measure

Changes proposed in this pull request:

- Correct quick measure for Profit: Update "subtracting the Cost column from **Profit** column" to "subtracting the Cost column from **Sales** column" 