### PR TITLE
Replaced minus symbol

### DIFF
--- a/Instructions/Labs/07-create-visual-calculations.md
+++ b/Instructions/Labs/07-create-visual-calculations.md
@@ -60,7 +60,7 @@ In this task, you’ll create a bar chart showing sales amount, total product co
 1. The visual calculations edit window opens. In the formula bar above the visual matrix enter the following expression and then Enter to commit the calculation:
 
     ```DAX
-   Profit = [Sum of Sales] – [Sum of Cost]
+   Profit = [Sum of Sales] - [Sum of Cost]
     ```
 
 1. Confirm you now see a Profit column on the visual matrix at the bottom of the screen:


### PR DESCRIPTION
The minus symbol in the first one (–) is a long dash.  The updated version uses the standard hyphen-minus (-)

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-