### PR TITLE
added instructions to avoid a fabric trial license

### DIFF
--- a/Instructions/Labs/08-design-power-bi-reports.md
+++ b/Instructions/Labs/08-design-power-bi-reports.md
@@ -325,6 +325,8 @@ In this task, you'll sync the _Year_ and _Region_ slicers.
 
 In this exercise, you'll publish the report to the Power BI service. You will then explore the published report behavior.
 
+> _**Note**: You'll need at least a **Power BI Free** license to publish the report. Open the Microsoft Edge browser, then sign in at `https://app.powerbi.com`. When asked to solve a puzzle, or to start a free Fabric trial, you can skip this and close the browser.
+
 > _**Note**: You can review the remainder of the exercise, even if you don't have access to the Power BI service to perform the tasks directly._
 
 1. Select the _Overview_ page, then save the Power BI Desktop file.

--- a/Instructions/Labs/09-enhance-power-bi-reports.md
+++ b/Instructions/Labs/09-enhance-power-bi-reports.md
@@ -249,6 +249,8 @@ In this exercise, you'll enhance the _My Performance_ page with buttons, allowin
 
 In this exercise, you'll publish the report to the Power BI service and explore the published report behavior.
 
+> _**Note**: You'll need at least a **Power BI Free** license to publish the report. Open the Microsoft Edge browser, then sign in at `https://app.powerbi.com`. When asked to solve a puzzle, or to start a free Fabric trial, you can skip this and close the browser.
+
 > _**Note**: You can review the remainder of the exercise, even if you don't have access to the Power BI service to perform the tasks directly._
 
 1. Select the _Overview_ page.

--- a/Instructions/Labs/12-create-power-bi-dashboard.md
+++ b/Instructions/Labs/12-create-power-bi-dashboard.md
@@ -25,6 +25,8 @@ To complete this exercise, first open a web browser and enter the following URL 
 
 Extract the folder to the **C:\Users\Student\Downloads\12-create-dashboard** folder.
 
+> _**Note**: You'll need at least a **Power BI Free** license to publish the report. Open the Microsoft Edge browser, then sign in at `https://app.powerbi.com`. When asked to solve a puzzle, or to start a free Fabric trial, you can skip this and close the browser.
+
 ## **Publish the report**
 
 In this task, you'll set up the environment for the lab by creating a semantic model.


### PR DESCRIPTION
Added following instructions to labs 8, 9 and 12. 

> _**Note**: You'll need at least a **Power BI Free** license to publish the report. Open the Microsoft Edge browser, then sign in at `https://app.powerbi.com`. When asked to solve a puzzle, or to start a free Fabric trial, you can skip this and close the browser.

Fixes #278 