### PR TITLE
fix for bug 280 conditional formatting

### DIFF
--- a/Instructions/Labs/09-enhance-power-bi-reports.md
+++ b/Instructions/Labs/09-enhance-power-bi-reports.md
@@ -100,10 +100,6 @@ In this exercise, you'll enhance the drillthrough page with conditional formatti
 
     ![Picture 9](Linked_image_Files/09-enhance-power-bi-reports_image29.png)
 
-1. In the **Icons – Profit Margin** window, in the **Apply to** dropdown list, select **Values and totals**.
-
-    ![Picture 10](Linked_image_Files/09-enhance-power-bi-reports_image30a.png)
-
 1. In the **Icons – Profit Margin** window, in the **Icon Layout** dropdown list, select **Right of Data**.
 
     ![Picture 11](Linked_image_Files/09-enhance-power-bi-reports_image30.png)
@@ -129,6 +125,10 @@ In this exercise, you'll enhance the drillthrough page with conditional formatti
     ![Picture 13](Linked_image_Files/09-enhance-power-bi-reports_image32.png)
 
     > _The rules can be interpreted as follows: display a red diamond if the profit margin value is less than 0; otherwise if the value is greater than or equal to zero, display a green circle._
+
+1. In the **Icons – Profit Margin** window, in the **Apply to** dropdown list, select **Values and totals**.
+
+    ![Picture 10](Linked_image_Files/09-enhance-power-bi-reports_image30a.png)
 
 1. Select **OK**.
 


### PR DESCRIPTION
fix for bug #280 

#### **Lab/Demo Number/Name**
Lab 9 - Enhance Power BI report designs / Task - add conditional formatting

#### **Describe the bug**
In step 2, the instructions have you change the "Apply to" dropdown to "Values and Totals". When that happens, you are unable to change the third controls in the UI (not sure if this is intentional or a PBI bug) - but you cant complete the step since you cant change the third condition (greyed out). 

#### **Screenshots**
First shot - you can see that if Values is selected, you can alter the data type

<img width="1367" height="776" alt="Image" src="https://github.com/user-attachments/assets/96742510-ec70-4f1a-9dd2-d4faa7a9fe75" />

This second image - you can see that changing to Values and Totals removes the ability to adjust the data types (greyed out)

<img width="1501" height="1041" alt="Image" src="https://github.com/user-attachments/assets/98569c74-61f8-4aeb-8751-6bd388680469" />


#### **Expected behavior/Suggested Change**
When "Values" and not "Values and Totals" is selected, you can change the third control to "Number". Then you can select "Values and Totals" under "Apply to" to make it work.

Essentially, you need to move Step 2 right below step 6 and it should work properly. Only the instructions need the order changed.