### PR TITLE
Backfill missing lab metadata (12 files)

### DIFF
--- a/Instructions/Labs/01-get-data-in-power-bi.md
+++ b/Instructions/Labs/01-get-data-in-power-bi.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: 'Get data in Power BI'
-    module: 'Get data in Power BI'
+  title: Get data in Power BI
+  module: Get data in Power BI
+  description: This lab is designed to introduce you to Power BI Desktop application
+    and how to connect to data and how to use data preview techniques to understand
+    the characteristics and quality of the source data.
+  duration: 30 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Power BI
 ---
 
 # Get data in Power BI

--- a/Instructions/Labs/02-transform-data-power-bi.md
+++ b/Instructions/Labs/02-transform-data-power-bi.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: 'Clean, transform, and load data in Power BI'
-    module: 'Clean, transform, and load data in Power BI'
+  title: Clean, transform, and load data in Power BI
+  module: Clean, transform, and load data in Power BI
+  description: In this lab, you'll use data cleansing and transformation techniques
+    to start shaping your data model. You'll then apply the queries to load each as
+    a table to the semantic model.
+  duration: 45 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Power BI
 ---
 
 # Clean, transform, and load data in Power BI

--- a/Instructions/Labs/03-configure-semantic-model.md
+++ b/Instructions/Labs/03-configure-semantic-model.md
@@ -1,7 +1,16 @@
 ---
 lab:
-    title: 'Configure a semantic model in Power BI'
-    module: 'Configure a semantic model in Power BI'
+  title: Configure a semantic model in Power BI
+  module: Configure a semantic model in Power BI
+  description: In this lab, you'll commence developing the data model. It will involve
+    creating relationships between tables, and then configuring table and column properties
+    to improve the friendliness and usability of the data model. You'll also create
+    hierarchies and quick measures.
+  duration: 45 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Power BI
 ---
 
 # Configure a semantic model in Power BI

--- a/Instructions/Labs/04-create-dax-calculations.md
+++ b/Instructions/Labs/04-create-dax-calculations.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Create DAX calculations in semantic models'
-    module: 'Create DAX calculations in semantic models'
+  title: Create DAX calculations in semantic models
+  module: Create DAX calculations in semantic models
+  description: In this lab, you'll create calculated tables, calculated columns, and
+    simple measures by using Data Analysis Expressions (DAX).
+  duration: 45 minutes
+  level: 200
+  islab: true
 ---
 
 # Create DAX calculations in semantic models

--- a/Instructions/Labs/05-modify-dax-filter-context.md
+++ b/Instructions/Labs/05-modify-dax-filter-context.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Modify DAX filter context in Power BI'
-    module: 'Modify DAX filter context in Power BI'
+  title: Modify DAX filter context in Power BI
+  module: Modify DAX filter context in Power BI
+  description: In this lab, you'll create measures with DAX expressions that involve
+    filter context manipulation.
+  duration: 30 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Power BI
 ---
 
 # Modify DAX filter context in Power BI

--- a/Instructions/Labs/06-use-dax-time-intelligence.md
+++ b/Instructions/Labs/06-use-dax-time-intelligence.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Use DAX time intelligence functions in Power BI'
-    module: 'Use DAX time intelligence functions in Power BI'
+  title: Use DAX time intelligence functions in Power BI
+  module: Use DAX time intelligence functions in Power BI
+  description: In this lab, you'll create measures with DAX expressions that involve
+    time intelligence.
+  duration: 15 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Power BI
 ---
 
 # Use DAX time intelligence functions in Power BI

--- a/Instructions/Labs/07-create-visual-calculations.md
+++ b/Instructions/Labs/07-create-visual-calculations.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Create visual calculations in Power BI Desktop'
-    module: 'Create visual calculations in Power BI Desktop'
+  title: Create visual calculations in Power BI Desktop
+  module: Create visual calculations in Power BI Desktop
+  description: In this lab, you'll create visual calculations using Data Analysis
+    Expressions (DAX).
+  duration: 30 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Power BI
 ---
 
 # Create visual calculations in Power BI Desktop

--- a/Instructions/Labs/08-design-power-bi-reports.md
+++ b/Instructions/Labs/08-design-power-bi-reports.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Design Power BI reports'
-    module: 'Design Power BI reports'
+  title: Design Power BI reports
+  module: Design Power BI reports
+  description: In this lab, you'll create a three-page report. You'll then publish
+    it to the Power BI service, where you'll open and interact with the report.
+  duration: 45 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Power BI
 ---
 
 # Design Power BI reports

--- a/Instructions/Labs/09-enhance-power-bi-reports.md
+++ b/Instructions/Labs/09-enhance-power-bi-reports.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Enhance Power BI report designs'
-    module: 'Enhance Power BI report designs for the user experience'
+  title: Enhance Power BI report designs
+  module: Enhance Power BI report designs for the user experience
+  description: In this lab, you'll enhance the _Sales Analysis_ report with advanced
+    design features.
+  duration: 45 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Power BI
 ---
 
 # Enhance Power BI report design

--- a/Instructions/Labs/10-perform-analytics-power-bi.md
+++ b/Instructions/Labs/10-perform-analytics-power-bi.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Perform analytics in Power BI'
-    module: 'Perform analytics in Power BI'
+  title: Perform analytics in Power BI
+  module: Perform analytics in Power BI
+  description: In this lab, you'll create the **Sales Exploration** report.
+  duration: 30 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Power BI
 ---
 
 # Perform analytics in Power BI

--- a/Instructions/Labs/11-secure-data-access.md
+++ b/Instructions/Labs/11-secure-data-access.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Secure data access in Power BI'
-    module: 'Secure data access in Power BI'
+  title: Secure data access in Power BI
+  module: Secure data access in Power BI
+  description: 'In this lab, you''ll enforce row-level security to ensure that a salesperson
+    can only analyze sales data for their assigned region(s). You learn how to:'
+  duration: 20 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Power BI
 ---
 
 # Secure data access in Power BI

--- a/Instructions/Labs/12-create-power-bi-dashboard.md
+++ b/Instructions/Labs/12-create-power-bi-dashboard.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: '(Optional) Create dashboards in Power BI'
-    module: 'Create dashboards in Power BI'
+  title: (Optional) Create dashboards in Power BI
+  module: Create dashboards in Power BI
+  description: In this lab, you'll create the **Sales Monitoring** dashboard in the
+    Power BI service using an existing report.
+  duration: 30 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Power BI
 ---
 
 # Create dashboards in Power BI


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 12

- `Instructions/Labs/01-get-data-in-power-bi.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/02-transform-data-power-bi.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/03-configure-semantic-model.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/04-create-dax-calculations.md` (description,duration,level,islab)
- `Instructions/Labs/05-modify-dax-filter-context.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/06-use-dax-time-intelligence.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/07-create-visual-calculations.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/08-design-power-bi-reports.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/09-enhance-power-bi-reports.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/10-perform-analytics-power-bi.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/11-secure-data-access.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/12-create-power-bi-dashboard.md` (description,duration,level,islab,primarytopics)
