### PR TITLE
Backfill missing lab metadata (12 files)

### DIFF
--- a/Instructions/Labs/01-get-data-in-power-bi.md
+++ b/Instructions/Labs/01-get-data-in-power-bi.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Get data in Power BI'
-    module: 'Get data in Power BI'
+  title: Get data in Power BI
+  module: Get data in Power BI
+  description: https://github.com/MicrosoftLearning/PL-300-Microsoft-Power-BI-Data-Analyst/raw/Main/Allfiles/Labs/01-get-data-in-power-bi/01-get-data.zip
+  duration: 30 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - GitHub
+    - Power BI
 ---
 
 # Get data in Power BI

--- a/Instructions/Labs/01-get-data-in-power-bi.md
+++ b/Instructions/Labs/01-get-data-in-power-bi.md
@@ -2,12 +2,11 @@
 lab:
   title: Get data in Power BI
   module: Get data in Power BI
-  description: https://github.com/MicrosoftLearning/PL-300-Microsoft-Power-BI-Data-Analyst/raw/Main/Allfiles/Labs/01-get-data-in-power-bi/01-get-data.zip
+  description: In this hands-on lab, you'll gain practical experience connecting Power BI Desktop to different data sources (including SQL Server) and importing data. You'll learn to use Power Query to preview source data and apply data profiling techniques to understand data characteristics and assess data quality. This foundational lab establishes essential skills for data acquisition and initial data assessment in Power BI.
   duration: 30 minutes
-  level: 200
+  level: 300
   islab: true
   primarytopics:
-    - GitHub
     - Power BI
 ---
 

--- a/Instructions/Labs/02-transform-data-power-bi.md
+++ b/Instructions/Labs/02-transform-data-power-bi.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Clean, transform, and load data in Power BI'
-    module: 'Clean, transform, and load data in Power BI'
+  title: Clean, transform, and load data in Power BI
+  module: Clean, transform, and load data in Power BI
+  description: In this lab, you'll use data cleansing and transformation techniques to start shaping your data model. You'll then apply the queries to load each as a table to the semantic model.
+  duration: 45 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Power BI
 ---
 
 # Clean, transform, and load data in Power BI

--- a/Instructions/Labs/02-transform-data-power-bi.md
+++ b/Instructions/Labs/02-transform-data-power-bi.md
@@ -2,9 +2,9 @@
 lab:
   title: Clean, transform, and load data in Power BI
   module: Clean, transform, and load data in Power BI
-  description: In this lab, you'll use data cleansing and transformation techniques to start shaping your data model. You'll then apply the queries to load each as a table to the semantic model.
+  description: In this hands-on lab, you'll use Power Query Editor to apply data cleansing and transformation techniques to shape your data model. You'll learn to perform various data transformations (like renaming columns, filtering data, and reshaping tables) and then load the transformed queries as tables into the semantic model.
   duration: 45 minutes
-  level: 200
+  level: 300
   islab: true
   primarytopics:
     - Power BI

--- a/Instructions/Labs/03-configure-semantic-model.md
+++ b/Instructions/Labs/03-configure-semantic-model.md
@@ -2,9 +2,9 @@
 lab:
   title: Configure a semantic model in Power BI
   module: Configure a semantic model in Power BI
-  description: In this lab, you'll commence developing the data model. It will involve creating relationships between tables, and then configuring table and column properties to improve the friendliness and usability of the data model. You'll also create hierarchies and quick measures.
+  description: In this hands-on lab, you'll develop a data model by creating relationships between tables and configuring table and column properties to improve usability and user-friendliness. You'll also learn to create hierarchies for drill-down analysis, build quick measures for common calculations, and configure many-to-many relationships to handle complex data scenarios.
   duration: 45 minutes
-  level: 100
+  level: 300
   islab: true
   primarytopics:
     - Power BI

--- a/Instructions/Labs/03-configure-semantic-model.md
+++ b/Instructions/Labs/03-configure-semantic-model.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Configure a semantic model in Power BI'
-    module: 'Configure a semantic model in Power BI'
+  title: Configure a semantic model in Power BI
+  module: Configure a semantic model in Power BI
+  description: In this lab, you'll commence developing the data model. It will involve creating relationships between tables, and then configuring table and column properties to improve the friendliness and usability of the data model. You'll also create hierarchies and quick measures.
+  duration: 45 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Power BI
 ---
 
 # Configure a semantic model in Power BI

--- a/Instructions/Labs/04-create-dax-calculations.md
+++ b/Instructions/Labs/04-create-dax-calculations.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Create DAX calculations in semantic models'
-    module: 'Create DAX calculations in semantic models'
+  title: Create DAX calculations in semantic models
+  module: Create DAX calculations in semantic models
+  description: In this lab, you'll create calculated tables, calculated columns, and simple measures by using Data Analysis Expressions (DAX).
+  duration: 45 minutes
+  level: 200
+  islab: true
 ---
 
 # Create DAX calculations in semantic models

--- a/Instructions/Labs/04-create-dax-calculations.md
+++ b/Instructions/Labs/04-create-dax-calculations.md
@@ -2,10 +2,12 @@
 lab:
   title: Create DAX calculations in semantic models
   module: Create DAX calculations in semantic models
-  description: In this lab, you'll create calculated tables, calculated columns, and simple measures by using Data Analysis Expressions (DAX).
+  description: In this hands-on lab, you'll learn to create DAX (Data Analysis Expressions) calculations to enhance your semantic model, including calculated tables, calculated columns, and measures. You'll gain practical experience writing DAX formulas using the formula bar with features like auto-complete and IntelliSense to build custom calculations that extend your data model's analytical capabilities.
   duration: 45 minutes
-  level: 200
+  level: 400
   islab: true
+  primarytopics:
+    - Power BI
 ---
 
 # Create DAX calculations in semantic models

--- a/Instructions/Labs/05-modify-dax-filter-context.md
+++ b/Instructions/Labs/05-modify-dax-filter-context.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Modify DAX filter context in Power BI'
-    module: 'Modify DAX filter context in Power BI'
+  title: Modify DAX filter context in Power BI
+  module: Modify DAX filter context in Power BI
+  description: In this lab, you'll create measures with DAX expressions that involve filter context manipulation.
+  duration: 30 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Power BI
 ---
 
 # Modify DAX filter context in Power BI

--- a/Instructions/Labs/05-modify-dax-filter-context.md
+++ b/Instructions/Labs/05-modify-dax-filter-context.md
@@ -2,9 +2,9 @@
 lab:
   title: Modify DAX filter context in Power BI
   module: Modify DAX filter context in Power BI
-  description: In this lab, you'll create measures with DAX expressions that involve filter context manipulation.
+  description: In this hands-on lab, you'll learn to create advanced DAX measures that manipulate filter context using the CALCULATE function. You'll gain practical experience controlling how filters are applied to your calculations, enabling you to create more sophisticated and flexible measures that can override or modify the default filter behavior in your reports.
   duration: 30 minutes
-  level: 100
+  level: 400
   islab: true
   primarytopics:
     - Power BI

--- a/Instructions/Labs/06-use-dax-time-intelligence.md
+++ b/Instructions/Labs/06-use-dax-time-intelligence.md
@@ -2,9 +2,9 @@
 lab:
   title: Use DAX time intelligence functions in Power BI
   module: Use DAX time intelligence functions in Power BI
-  description: In this lab, you'll create measures with DAX expressions that involve time intelligence.
+  description: In this hands-on lab, you'll learn to create DAX measures using time intelligence functions to perform date-specific calculations such as year-to-date (YTD), prior year comparisons, and other time-based aggregations. You'll gain practical experience manipulating filter context to analyze data across different time periods, enabling you to build powerful temporal analytics into your Power BI reports.
   duration: 15 minutes
-  level: 100
+  level: 400
   islab: true
   primarytopics:
     - Power BI

--- a/Instructions/Labs/06-use-dax-time-intelligence.md
+++ b/Instructions/Labs/06-use-dax-time-intelligence.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Use DAX time intelligence functions in Power BI'
-    module: 'Use DAX time intelligence functions in Power BI'
+  title: Use DAX time intelligence functions in Power BI
+  module: Use DAX time intelligence functions in Power BI
+  description: In this lab, you'll create measures with DAX expressions that involve time intelligence.
+  duration: 15 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Power BI
 ---
 
 # Use DAX time intelligence functions in Power BI

--- a/Instructions/Labs/07-create-visual-calculations.md
+++ b/Instructions/Labs/07-create-visual-calculations.md
@@ -2,9 +2,9 @@
 lab:
   title: Create visual calculations in Power BI Desktop
   module: Create visual calculations in Power BI Desktop
-  description: In this lab, you'll create visual calculations using Data Analysis Expressions (DAX).
+  description: In this hands-on lab, you'll learn to create and edit visual calculations using DAX functions like PREVIOUS(), RUNNINGSUM(), and MOVINGAVERAGE() to build comparison metrics between fiscal years. You'll gain practical experience using optional Axis and Reset parameters to customize cumulative calculations in multi-leveled axes, enabling you to create dynamic, context-aware calculations directly within your Power BI visuals.
   duration: 30 minutes
-  level: 100
+  level: 300
   islab: true
   primarytopics:
     - Power BI

--- a/Instructions/Labs/07-create-visual-calculations.md
+++ b/Instructions/Labs/07-create-visual-calculations.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Create visual calculations in Power BI Desktop'
-    module: 'Create visual calculations in Power BI Desktop'
+  title: Create visual calculations in Power BI Desktop
+  module: Create visual calculations in Power BI Desktop
+  description: In this lab, you'll create visual calculations using Data Analysis Expressions (DAX).
+  duration: 30 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Power BI
 ---
 
 # Create visual calculations in Power BI Desktop

--- a/Instructions/Labs/08-design-power-bi-reports.md
+++ b/Instructions/Labs/08-design-power-bi-reports.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Design Power BI reports'
-    module: 'Design Power BI reports'
+  title: Design Power BI reports
+  module: Design Power BI reports
+  description: In this task, you'll publish the report to the Power BI service. You will then explore the published report behavior.
+  duration: 45 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Power BI
 ---
 
 # Design Power BI reports

--- a/Instructions/Labs/08-design-power-bi-reports.md
+++ b/Instructions/Labs/08-design-power-bi-reports.md
@@ -2,9 +2,9 @@
 lab:
   title: Design Power BI reports
   module: Design Power BI reports
-  description: In this task, you'll publish the report to the Power BI service. You will then explore the published report behavior.
+  description: In this hands-on lab, you'll design a multi-page Power BI report by configuring visuals, formatting properties, and synchronizing slicers to create an interactive experience. You'll then publish your report to the Power BI service and learn to interact with the published report and its visuals in the cloud environment.
   duration: 45 minutes
-  level: 100
+  level: 300
   islab: true
   primarytopics:
     - Power BI

--- a/Instructions/Labs/09-enhance-power-bi-reports.md
+++ b/Instructions/Labs/09-enhance-power-bi-reports.md
@@ -2,9 +2,9 @@
 lab:
   title: Enhance Power BI report designs
   module: Enhance Power BI report designs for the user experience
-  description: In this exercise, you'll publish the report to the Power BI service and explore the published report behavior.
+  description: In this hands-on lab, you'll enhance your Power BI reports with advanced design features including drill-through pages for detailed analysis, conditional formatting to highlight key insights, and interactive bookmarks and buttons for improved navigation. You'll gain practical experience creating sophisticated, user-friendly reports that provide deeper insights and better user experience through these advanced interactivity features.
   duration: 45 minutes
-  level: 100
+  level: 300
   islab: true
   primarytopics:
     - Power BI

--- a/Instructions/Labs/09-enhance-power-bi-reports.md
+++ b/Instructions/Labs/09-enhance-power-bi-reports.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Enhance Power BI report designs'
-    module: 'Enhance Power BI report designs for the user experience'
+  title: Enhance Power BI report designs
+  module: Enhance Power BI report designs for the user experience
+  description: In this exercise, you'll publish the report to the Power BI service and explore the published report behavior.
+  duration: 45 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Power BI
 ---
 
 # Enhance Power BI report design

--- a/Instructions/Labs/10-perform-analytics-power-bi.md
+++ b/Instructions/Labs/10-perform-analytics-power-bi.md
@@ -2,9 +2,9 @@
 lab:
   title: Perform analytics in Power BI
   module: Perform analytics in Power BI
-  description: In this lab, you'll create the Sales Exploration report.
+  description: In this hands-on lab, you'll create a Sales Exploration report and learn to perform advanced analytics in Power BI using animated scatter charts and forecasting capabilities. You'll gain practical experience building dynamic scatter charts that visualize data patterns over time through animation and using built-in analytical features to forecast future values directly within your visuals.
   duration: 30 minutes
-  level: 100
+  level: 300
   islab: true
   primarytopics:
     - Power BI

--- a/Instructions/Labs/10-perform-analytics-power-bi.md
+++ b/Instructions/Labs/10-perform-analytics-power-bi.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Perform analytics in Power BI'
-    module: 'Perform analytics in Power BI'
+  title: Perform analytics in Power BI
+  module: Perform analytics in Power BI
+  description: In this lab, you'll create the Sales Exploration report.
+  duration: 30 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Power BI
 ---
 
 # Perform analytics in Power BI

--- a/Instructions/Labs/11-secure-data-access.md
+++ b/Instructions/Labs/11-secure-data-access.md
@@ -2,9 +2,9 @@
 lab:
   title: Secure data access in Power BI
   module: Secure data access in Power BI
-  description: 'In this lab, you''ll enforce row-level security to ensure that a salesperson can only analyze sales data for their assigned region(s). You learn how to:'
+  description: In this hands-on lab, you'll learn to implement dynamic row-level security (RLS) in Power BI to restrict data access based on user identity. You'll create and test security roles using the USERPRINCIPALNAME() function to ensure that salespeople can only analyze sales data for their assigned region(s), protecting sensitive information and providing personalized data views.
   duration: 20 minutes
-  level: 100
+  level: 300
   islab: true
   primarytopics:
     - Power BI

--- a/Instructions/Labs/11-secure-data-access.md
+++ b/Instructions/Labs/11-secure-data-access.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Secure data access in Power BI'
-    module: 'Secure data access in Power BI'
+  title: Secure data access in Power BI
+  module: Secure data access in Power BI
+  description: 'In this lab, you''ll enforce row-level security to ensure that a salesperson can only analyze sales data for their assigned region(s). You learn how to:'
+  duration: 20 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Power BI
 ---
 
 # Secure data access in Power BI

--- a/Instructions/Labs/12-create-power-bi-dashboard.md
+++ b/Instructions/Labs/12-create-power-bi-dashboard.md
@@ -2,9 +2,9 @@
 lab:
   title: (Optional) Create dashboards in Power BI
   module: Create dashboards in Power BI
-  description: In this lab, you'll create the Sales Monitoring dashboard in the Power BI service using an existing report.
+  description: In this hands-on lab, you'll learn to create a Sales Monitoring dashboard in the Power BI service by pinning visuals from an existing report and using Q&A (natural language queries) to create dashboard tiles. You'll gain practical experience building interactive dashboards that consolidate key metrics and insights from multiple reports into a single, easy-to-consume view for monitoring business performance.
   duration: 30 minutes
-  level: 200
+  level: 300
   islab: true
   primarytopics:
     - Power BI

--- a/Instructions/Labs/12-create-power-bi-dashboard.md
+++ b/Instructions/Labs/12-create-power-bi-dashboard.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: '(Optional) Create dashboards in Power BI'
-    module: 'Create dashboards in Power BI'
+  title: (Optional) Create dashboards in Power BI
+  module: Create dashboards in Power BI
+  description: In this lab, you'll create the Sales Monitoring dashboard in the Power BI service using an existing report.
+  duration: 30 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Power BI
 ---
 
 # Create dashboards in Power BI


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 12

- `Instructions/Labs/01-get-data-in-power-bi.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/02-transform-data-power-bi.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/03-configure-semantic-model.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/04-create-dax-calculations.md` (description,duration,level,islab)
- `Instructions/Labs/05-modify-dax-filter-context.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/06-use-dax-time-intelligence.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/07-create-visual-calculations.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/08-design-power-bi-reports.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/09-enhance-power-bi-reports.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/10-perform-analytics-power-bi.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/11-secure-data-access.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/12-create-power-bi-dashboard.md` (description,duration,level,islab,primarytopics)
